### PR TITLE
docs: Update quickstart doc for using different auth methods

### DIFF
--- a/docs/quickstart.md
+++ b/docs/quickstart.md
@@ -97,11 +97,14 @@ This is the traditional method using OCI API keys.
    --from-literal=credentials='{
    "tenancy_ocid": "REPLACE_WITH_YOUR_TENANCY_OCID",
    "user_ocid": "REPLACE_WITH_YOUR_USER_OCID",
-   "private_key": "REPLACE_WITH_YOUR_PRIVATE_KEY",
+   "private_key": "-----BEGIN RSA PRIVATE KEY-----\nMIIE...REPLACE_WITH_YOUR_KEY_CONTENT...AB\n-----END RSA PRIVATE KEY-----\n",
    "fingerprint": "REPLACE_WITH_YOUR_FINGERPRINT",
-   "region": "REPLACE_WITH_YOUR_REGION"
+   "region": "REPLACE_WITH_YOUR_REGION",
+   "auth": "ApiKey"
    }'
    ```
+   `private_key` must be the full PEM private key with newline characters escaped as `\n` and a trailing newline at the end.
+   If your key content includes additional lines (for example, `OCI_API_KEY`), keep them inside the same quoted `private_key` value and escape each newline as `\n`.
    **Note:** Refer to `examples/providerconfig/secret.yaml.tmpl` for all available options. Additional reference [SDKConfig](https://docs.oracle.com/en-us/iaas/Content/API/Concepts/sdkconfig.htm).
 
 ### Instance Principal Authentication


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes
I updated the quickstart.md doc for adding two new methods for doing authentication:

- instance principal 
- workload identity

Now users could choose one method to configure ProviderConfig.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes https://github.com/oracle/crossplane-provider-oci/issues/69

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested
Created bucket resource using both instance principal and workload identity.
<img width="670" height="68" alt="Screenshot 2026-02-17 at 09 29 16" src="https://github.com/user-attachments/assets/435c6814-7321-4295-a1d1-6ed0c9eda7e5" />


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
