### PR TITLE
fix broken provider.go referencing non-existent ons.config

### DIFF
--- a/config/provider.go
+++ b/config/provider.go
@@ -19,6 +19,7 @@ package config
 import (
 	// Note(turkenh): we are importing this to embed provider schema document
 	_ "embed"
+
 	"github.com/crossplane/upjet/pkg/config"
 	"github.com/crossplane/upjet/pkg/registry/reference"
 
@@ -89,7 +90,6 @@ func GetProvider() *config.Provider {
 		core.Configure,
 		kms.Configure,
 		containerengine.Configure,
-		ons.Configure,
 		networkloadbalancer.Configure,
 		dns.Configure,
 		healthchecks.Configure,


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

Removed `ons.Configure` line from config/provider.go as there is no existing `ons/config.go` from https://github.com/oracle/crossplane-provider-oci/pull/82

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.
12:14:53 [ OK ] go generate linux_arm64
12:14:53 [ .. ] go mod tidy
12:14:54 [ OK ] go mod tidy
12:14:54 [ .. ] checking that branch is clean
12:14:55 [ OK ] branch is clean

### How has this code been tested
Fixes broken reference. `make generate` runs successfully now.
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
