### PR TITLE
fix: key label in certificateauthority

### DIFF
--- a/examples/certificatesmanagement/v1alpha1/certificateauthority.yaml
+++ b/examples/certificatesmanagement/v1alpha1/certificateauthority.yaml
@@ -16,5 +16,5 @@ spec:
           - commonName: www.example.com
     kmsKeyIdSelector:
       matchLabels:
-        testing.upbound.io/example-name: key_label_1
+        testing.upbound.io/example-name: key_label_2
     name: certificateauthority1


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

fix certificateauthority to point to an RSA key type.

certificateauthority needs a key of RSA type but currently it points to AES key type.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
