### PR TITLE
Add macaron check github actions

### DIFF
--- a/.github/workflows/macaron-check-github-actions.yaml
+++ b/.github/workflows/macaron-check-github-actions.yaml
@@ -27,11 +27,13 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
         with:
+          fetch-depth: 0
           persist-credentials: false
+          ref: ${{ github.event.pull_request.head.sha || github.sha }}
 
       - name: Run Macaron check-github-actions policy
         uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
         with:
-          repo_path: https://github.com/${{ github.repository }}
+          repo_path: ./
           policy_file: check-github-actions
-          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}
+          policy_purl: pkg:github.com/${{ github.repository }}@${{ github.event.pull_request.head.sha || github.sha }}

--- a/.github/workflows/macaron-check-github-actions.yaml
+++ b/.github/workflows/macaron-check-github-actions.yaml
@@ -1,0 +1,37 @@
+name: Macaron check-github-actions
+
+on:
+  pull_request:
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  push:
+    branches:
+      - main
+      - master
+    paths:
+      - ".github/workflows/**"
+      - ".github/actions/**"
+  workflow_dispatch:
+  schedule:
+    - cron: "0 8 * * 1"
+
+permissions:
+  contents: read
+
+jobs:
+  macaron-check-github-actions:
+    name: Macaron policy verification
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
+        with:
+          persist-credentials: false
+
+      - name: Run Macaron check-github-actions policy
+        uses: oracle/macaron@b31acfe389133a5587d9639063ec70cb84e7bc47 # v0.23.0
+        with:
+          repo_path: https://github.com/${{ github.repository }}
+          policy_file: check-github-actions
+          policy_purl: pkg:github/${{ github.repository }}@${{ github.sha }}

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -29,6 +29,10 @@ on:
         description: "Number of smaller provider packages to build and push with each build job"
         default: '30'
         required: true
+
+permissions:
+  contents: read
+
 env:
   # Common versions
   DOCKER_BUILDX_VERSION: 'v0.20.1'
@@ -68,6 +72,9 @@ jobs:
 
     needs: index
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
     steps:
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -81,7 +81,7 @@ jobs:
           install: true
 
       - name: Login to GHCR using PAT
-        uses: docker/login-action@v3.3.0
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}

--- a/.github/workflows/tag.yaml
+++ b/.github/workflows/tag.yaml
@@ -14,6 +14,9 @@ on:
         description: 'Tag message'
         required: true
 
+permissions:
+  contents: write
+
 jobs:
   create-tag:
     runs-on: ubuntu-latest


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

## Summary
Add Macaron policy verification for GitHub Actions using the `check-github-actions` policy.

## What this change does
- Adds a dedicated workflow for Macaron verification
- Checks workflow definitions and local composite actions
- Uses pinned actions and disables persisted checkout credentials

## Why this is required
This helps detect unsafe or vulnerable GitHub Actions usage and reduces risk from software supply chain attacks targeting CI/CD pipelines.

## Required follow-up
- Enable `Macaron policy verification` as a required status check for protected branches
- Resolve any policy findings before merge if applicable

I have:

- [x] Read and followed Crossplane's [contribution process].

### How has this code been tested

Result on main branch run on forked repo. The same result must appear at PR check.

<img width="1112" height="1082" alt="Screenshot 2026-04-20 at 3 29 59 PM" src="https://github.com/user-attachments/assets/fee798b1-1c16-4ce5-bbfb-ede310267ee2" />


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
