### PR TITLE
Update provider package publish workflow

### DIFF
--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -27,7 +27,7 @@ on:
         required: false
       size:
         description: "Number of smaller provider packages to build and push with each build job"
-        default: '30'
+        default: '10'
         required: true
 
 permissions:
@@ -115,6 +115,7 @@ jobs:
 
   publish-artifacts:
     strategy:
+      max-parallel: 4
       matrix:
         index: ${{ fromJSON(needs.index.outputs.indices) }}
 
@@ -124,6 +125,16 @@ jobs:
       contents: read
       packages: write
     steps:
+      - name: Free disk space
+        run: |
+          set -euo pipefail
+          echo "Disk usage before cleanup:"
+          df -h
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
+          docker system prune -af || true
+          echo "Disk usage after cleanup:"
+          df -h
+
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
         with:
@@ -201,18 +212,16 @@ jobs:
           )
           echo "packages_batch=$PACKAGES_BATCH" >> "$GITHUB_OUTPUT"
 
-      - name: Build Artifacts
-        id: build_artifacts
+      - name: Generate Artifacts
+        id: generate_artifacts
         env:
-          INPUT_PLATFORM: ${{ inputs.platform }}
-          # We're using docker buildx, which doesn't actually load the images it
-          # builds by default. Specifying --load does so.
-          BUILD_ARGS: "--load"
+          PACKAGES_BATCH: ${{ steps.packages.outputs.packages_batch }}
         run: |
           set -euo pipefail
+          echo "Generating artifacts for: $PACKAGES_BATCH"
           go install golang.org/x/tools/cmd/goimports@latest
           make generate
-          make SUBPACKAGES="${{ steps.packages.outputs.packages_batch }}" PLATFORMS="$INPUT_PLATFORM" build
+          df -h
 
       - name: Publish Artifacts
         env:
@@ -220,11 +229,16 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_PLATFORM: ${{ inputs.platform }}
           REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
         run: |
           set -euo pipefail
 
           batch_platforms=$(tr ' ' ',' <<<"$INPUT_PLATFORM")
+          df -h
           make \
+            CONCURRENCY=5 \
             SUBPACKAGES_FOR_BATCH="$PACKAGES_BATCH" \
             XPKG_REG_ORGS="$REGISTRY_ORG" \
             VERSION="$INPUT_VERSION" \

--- a/build/makelib/subpackage.mk
+++ b/build/makelib/subpackage.mk
@@ -121,7 +121,11 @@ batch-process: $(UP) kustomize-crds
 build-subpackages:
 	@PLATFORMS_FOR_BUILD=$$(echo "$(BATCH_PLATFORMS)" | tr ',' ' '); \
 	$(MAKE) build PLATFORMS="$$PLATFORMS_FOR_BUILD" SUBPACKAGES="$(SUBPACKAGES_FOR_BATCH)"; \
+	$(GO) clean -cache -testcache || true; \
+	docker buildx prune -af || true; \
 	for platform in $$PLATFORMS_FOR_BUILD; do \
+		docker buildx prune -af || true; \
+		docker image prune -f || true; \
 		$(MAKE) build.family.image PLATFORM=$$platform || exit 1; \
 	done; \
 	$(MAKE) batch-process SUBPACKAGES_FOR_BATCH="$(SUBPACKAGES_FOR_BATCH)" BUILD_ONLY=true BATCH_PLATFORMS="$(BATCH_PLATFORMS)"
@@ -132,7 +136,11 @@ build-subpackages:
 publish-subpackages: kustomize-crds
 	@PLATFORMS_FOR_BUILD=$$(echo "$(BATCH_PLATFORMS)" | tr ',' ' '); \
 	$(MAKE) build PLATFORMS="$$PLATFORMS_FOR_BUILD" SUBPACKAGES="$(SUBPACKAGES_FOR_BATCH)"; \
+	$(GO) clean -cache -testcache || true; \
+	docker buildx prune -af || true; \
 	for platform in $$PLATFORMS_FOR_BUILD; do \
+		docker buildx prune -af || true; \
+		docker image prune -f || true; \
 		$(MAKE) build.family.image PLATFORM=$$platform || exit 1; \
 	done; \
 	$(MAKE) batch-process SUBPACKAGES_FOR_BATCH="$(SUBPACKAGES_FOR_BATCH)" BUILD_ONLY=false BATCH_PLATFORMS="$(BATCH_PLATFORMS)"


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

updates the provider package publishing workflow to reduce GitHub Actions runner disk pressure during subpackage publishing.

[Update provider package publish workflow](https://github.com/oracle/crossplane-provider-oci/commit/0d54a0f67eda4f4b694cc9bf69e06cb61ceabe87)
 - Adds a disk cleanup step to the `Publish Provider Packages` workflow before build setup.
  - Removes the duplicate pre-publish subpackage build from the workflow. The `publish-subpackages` Make target already builds the selected batch before publishing.
  - Keeps publish batching constrained with:
    - `max-parallel: 4`
    - `CONCURRENCY=5`

  - Adds cleanup in `build/makelib/subpackage.mk` after subpackage builds and before family image builds:
    - clears Go build/test cache
    - prunes Docker Buildx cache
    - prunes dangling Docker images before each family image build


<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

The publish workflow was failing on hosted GitHub runners with `No space left on device`, especially while building/importing the provider family base image for multi-arch packages.
  The runner could fill up enough that the GitHub Actions worker could not write its own diagnostic logs.


I have:

- [x] Read and followed Crossplane's [contribution process].
- [ ] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [ ] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested


<img width="1205" height="758" alt="Screenshot 2026-05-19 at 5 19 12 PM" src="https://github.com/user-attachments/assets/5f989b6d-0109-4420-b3a4-74649b149a82" />
<img width="1295" height="614" alt="Screenshot 2026-05-19 at 5 19 32 PM" src="https://github.com/user-attachments/assets/d898bfd1-3437-4313-8018-b840964fc458" />
<img width="1158" height="770" alt="Screenshot 2026-05-19 at 5 19 52 PM" src="https://github.com/user-attachments/assets/7df275b2-8c8d-4554-ac33-a145dea3e10a" />
<img width="635" height="176" alt="Screenshot 2026-05-19 at 5 20 30 PM" src="https://github.com/user-attachments/assets/27269d1a-6493-470d-8309-3631894f0a69" />
<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
