### PR TITLE
Optimize publish workflow with better caching and ordered building

### DIFF
--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -29,6 +29,11 @@ on:
         description: "Number of smaller provider packages to build and push with each build job"
         default: '10'
         required: true
+      cleanup-disk:
+        type: boolean
+        description: "Whether to clean runner disk space before publishing"
+        default: true
+        required: false
 
 permissions:
   contents: read
@@ -46,6 +51,7 @@ jobs:
     outputs:
       indices: ${{ steps.calc.outputs.indices }}
       subpackages: ${{ steps.calc.outputs.subpackages }}
+      has_services: ${{ steps.calc.outputs.has_services }}
     steps:
       - name: Validate workflow inputs
         env:
@@ -92,13 +98,19 @@ jobs:
 
           if [ "$INPUT_SUBPACKAGES" = "all" ]; then
             SERVICES_LIST=$(find examples-generated/cluster -mindepth 1 -maxdepth 1 -type d 2>/dev/null | xargs -n1 basename | tr '\n' ',' | sed 's/,$//' || echo "")
-            if [ -n "$SERVICES_LIST" ]; then
-              SUBPACKAGES="config,$SERVICES_LIST"
-            else
-              SUBPACKAGES="config"
-            fi
+            SUBPACKAGES="$SERVICES_LIST"
           else
-            SUBPACKAGES="$INPUT_SUBPACKAGES"
+            SUBPACKAGES=$(python3 - <<'PY'
+          import os
+
+          subpackages = [
+              pkg
+              for pkg in os.environ["INPUT_SUBPACKAGES"].split(",")
+              if pkg and pkg != "config"
+          ]
+          print(",".join(subpackages))
+          PY
+          )
           fi
           export SUBPACKAGES
           INDICES=$(python3 - <<'PY'
@@ -112,28 +124,152 @@ jobs:
           )
           echo "indices=$INDICES" >> "$GITHUB_OUTPUT"
           echo "subpackages=$SUBPACKAGES" >> "$GITHUB_OUTPUT"
+          if [ -n "$SUBPACKAGES" ]; then
+            echo "has_services=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "has_services=false" >> "$GITHUB_OUTPUT"
+          fi
 
-  publish-artifacts:
-    strategy:
-      max-parallel: 4
-      matrix:
-        index: ${{ fromJSON(needs.index.outputs.indices) }}
-
+  publish-family:
     needs: index
     runs-on: ubuntu-latest
     permissions:
       contents: read
       packages: write
+    outputs:
+      version: ${{ steps.version.outputs.version }}
     steps:
-      - name: Free disk space
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
+
+      - name: Setup QEMU
+        uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
+        with:
+          platforms: all
+
+      - name: Setup Docker Buildx
+        uses: docker/setup-buildx-action@885d1462b80bc1c1c7f0b00334ad271f09369c55 # v2
+        with:
+          version: ${{ env.DOCKER_BUILDX_VERSION }}
+          install: true
+
+      - name: Login to GHCR using PAT
+        uses: docker/login-action@9780b0c442fbb1117ed29e0efdff1e18412f7567 # v3.3.0
+        with:
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Checkout
+        uses: actions/checkout@8ade135a41bc03ea155e62e844d188df1ea18608 # v4
+        with:
+          submodules: true
+
+      - name: Fetch History
+        run: git fetch --prune --unshallow
+
+      - name: Setup Go
+        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
+        with:
+          go-version: ${{ inputs.go-version }}
+
+      - name: Find the Go Build Cache
+        id: go_cache
+        run: |
+          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT && \
+          echo "mod_cache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
+
+      - name: Cache the Go Build Cache
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: ${{ steps.go_cache.outputs.cache }}
+          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-build-publish-artifacts-
+
+      - name: Cache Go Dependencies
+        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
+        with:
+          path: ${{ steps.go_cache.outputs.mod_cache }}
+          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
+          restore-keys: ${{ runner.os }}-pkg-
+
+      - name: Vendor Dependencies
+        run: make vendor vendor.check
+
+      - name: Determine Version
+        id: version
+        env:
+          INPUT_VERSION: ${{ inputs.version }}
         run: |
           set -euo pipefail
-          echo "Disk usage before cleanup:"
+
+          if [ -n "$INPUT_VERSION" ]; then
+            version="$INPUT_VERSION"
+          else
+            version=$(make -s build.vars | sed -n 's/^VERSION=//p')
+          fi
+          echo "version=$version" >> "$GITHUB_OUTPUT"
+
+      - name: Install goimports
+        run: go install golang.org/x/tools/cmd/goimports@latest
+
+      - name: Check Generated Diff
+        run: make check-diff
+
+      - name: Publish Family Provider
+        env:
+          INPUT_VERSION: ${{ steps.version.outputs.version }}
+          INPUT_PLATFORM: ${{ inputs.platform }}
+          REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
+          # We're using docker buildx, which doesn't actually load the images it
+          # builds by default. Specifying --load does so.
+          BUILD_ARGS: "--load"
+        run: |
+          set -euo pipefail
+
+          batch_platforms=$(tr ' ' ',' <<<"$INPUT_PLATFORM")
           df -h
-          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /usr/local/.ghcup /opt/hostedtoolcache/CodeQL || true
-          docker system prune -af || true
-          echo "Disk usage after cleanup:"
-          df -h
+          make \
+            CONCURRENCY=5 \
+            SUBPACKAGES_FOR_BATCH="config" \
+            XPKG_REG_ORGS="$REGISTRY_ORG" \
+            VERSION="$INPUT_VERSION" \
+            BATCH_PLATFORMS="$batch_platforms" \
+            publish-subpackages
+
+  publish-services:
+    if: ${{ needs.index.outputs.has_services == 'true' }}
+    strategy:
+      max-parallel: 4
+      matrix:
+        index: ${{ fromJSON(needs.index.outputs.indices) }}
+
+    needs:
+      - index
+      - publish-family
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Cleanup Disk
+        uses: jlumbroso/free-disk-space@54081f138730dfa15788a46383842cd2f914a1be # v1.3.1
+        if: ${{ inputs.cleanup-disk }}
+        with:
+          android: true
+          dotnet: true
+          haskell: true
+          tool-cache: true
+          large-packages: false
+          swap-storage: false
 
       - name: Setup QEMU
         uses: docker/setup-qemu-action@2b82ce82d56a2a04d2637cd93a637ae1b359c0a7 # v2
@@ -205,30 +341,33 @@ jobs:
           size = int(os.environ["INPUT_SIZE"])
           start_idx = int(os.environ["MATRIX_INDEX"]) * size
           batch = all_packages[start_idx:start_idx + size]
-          if "config" not in batch:
-              batch = ["config"] + batch
+          if "config" in batch:
+              raise SystemExit("service batch must not include config")
           print(",".join(batch))
           PY
           )
           echo "packages_batch=$PACKAGES_BATCH" >> "$GITHUB_OUTPUT"
 
-      - name: Generate Artifacts
-        id: generate_artifacts
+      - name: Pull Family Provider
+        id: family
         env:
-          PACKAGES_BATCH: ${{ steps.packages.outputs.packages_batch }}
+          REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
+          VERSION: ${{ needs.publish-family.outputs.version }}
         run: |
           set -euo pipefail
-          echo "Generating artifacts for: $PACKAGES_BATCH"
-          go install golang.org/x/tools/cmd/goimports@latest
-          make generate
-          df -h
 
-      - name: Publish Artifacts
+          family_base_image="$REGISTRY_ORG/provider-family-oci:$VERSION"
+          docker pull "$family_base_image"
+          docker image inspect "$family_base_image"
+          echo "family_base_image=$family_base_image" >> "$GITHUB_OUTPUT"
+
+      - name: Publish Service Artifacts
         env:
           PACKAGES_BATCH: ${{ steps.packages.outputs.packages_batch }}
-          INPUT_VERSION: ${{ inputs.version }}
+          INPUT_VERSION: ${{ needs.publish-family.outputs.version }}
           INPUT_PLATFORM: ${{ inputs.platform }}
           REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
+          FAMILY_BASE_IMAGE: ${{ steps.family.outputs.family_base_image }}
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
           BUILD_ARGS: "--load"
@@ -240,7 +379,8 @@ jobs:
           make \
             CONCURRENCY=5 \
             SUBPACKAGES_FOR_BATCH="$PACKAGES_BATCH" \
+            FAMILY_BASE_IMAGE="$FAMILY_BASE_IMAGE" \
             XPKG_REG_ORGS="$REGISTRY_ORG" \
             VERSION="$INPUT_VERSION" \
             BATCH_PLATFORMS="$batch_platforms" \
-            publish-subpackages
+            publish-service-subpackages

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -29,6 +29,10 @@ on:
         description: "Number of smaller provider packages to build and push with each build job"
         default: '10'
         required: true
+      concurrency:
+        description: "Number of provider packages to process concurrently within each build job"
+        default: '2'
+        required: true
       cleanup-disk:
         type: boolean
         description: "Whether to clean runner disk space before publishing"
@@ -59,6 +63,7 @@ jobs:
           INPUT_VERSION: ${{ inputs.version }}
           INPUT_PLATFORM: ${{ inputs.platform }}
           INPUT_SIZE: ${{ inputs.size }}
+          INPUT_CONCURRENCY: ${{ inputs.concurrency }}
         run: |
           set -euo pipefail
 
@@ -74,6 +79,11 @@ jobs:
 
           if [[ ! "$INPUT_SIZE" =~ ^[1-9][0-9]*$ ]]; then
             echo "Invalid size input: $INPUT_SIZE" >&2
+            exit 1
+          fi
+
+          if [[ ! "$INPUT_CONCURRENCY" =~ ^[1-9][0-9]*$ ]]; then
+            echo "Invalid concurrency input: $INPUT_CONCURRENCY" >&2
             exit 1
           fi
 
@@ -180,26 +190,8 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
           go-version: ${{ inputs.go-version }}
-
-      - name: Find the Go Build Cache
-        id: go_cache
-        run: |
-          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT && \
-          echo "mod_cache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        with:
-          path: ${{ steps.go_cache.outputs.cache }}
-          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-publish-artifacts-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        with:
-          path: ${{ steps.go_cache.outputs.mod_cache }}
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -228,6 +220,7 @@ jobs:
         env:
           INPUT_VERSION: ${{ steps.version.outputs.version }}
           INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_CONCURRENCY: ${{ inputs.concurrency }}
           REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
           # We're using docker buildx, which doesn't actually load the images it
           # builds by default. Specifying --load does so.
@@ -238,10 +231,11 @@ jobs:
           batch_platforms=$(tr ' ' ',' <<<"$INPUT_PLATFORM")
           df -h
           make \
-            CONCURRENCY=5 \
+            CONCURRENCY="$INPUT_CONCURRENCY" \
             SUBPACKAGES_FOR_BATCH="config" \
             XPKG_REG_ORGS="$REGISTRY_ORG" \
             VERSION="$INPUT_VERSION" \
+            SKIP_GO_CACHE_CLEAN=true \
             BATCH_PLATFORMS="$batch_platforms" \
             publish-subpackages
 
@@ -301,26 +295,8 @@ jobs:
         uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
         with:
           go-version: ${{ inputs.go-version }}
-
-      - name: Find the Go Build Cache
-        id: go_cache
-        run: |
-          echo "cache=$(make go.cachedir)" >> $GITHUB_OUTPUT && \
-          echo "mod_cache=$(make go.mod.cachedir)" >> $GITHUB_OUTPUT
-
-      - name: Cache the Go Build Cache
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        with:
-          path: ${{ steps.go_cache.outputs.cache }}
-          key: ${{ runner.os }}-build-publish-artifacts-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-build-publish-artifacts-
-
-      - name: Cache Go Dependencies
-        uses: actions/cache@d4323d4df104b026a6aa633fdb11d772146be0bf # v4
-        with:
-          path: ${{ steps.go_cache.outputs.mod_cache }}
-          key: ${{ runner.os }}-pkg-${{ hashFiles('**/go.sum') }}
-          restore-keys: ${{ runner.os }}-pkg-
+          cache: true
+          cache-dependency-path: go.sum
 
       - name: Vendor Dependencies
         run: make vendor vendor.check
@@ -351,14 +327,24 @@ jobs:
       - name: Pull Family Provider
         id: family
         env:
+          INPUT_PLATFORM: ${{ inputs.platform }}
           REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
           VERSION: ${{ needs.publish-family.outputs.version }}
         run: |
           set -euo pipefail
 
           family_base_image="$REGISTRY_ORG/provider-family-oci:$VERSION"
-          docker pull "$family_base_image"
-          docker image inspect "$family_base_image"
+          family_manifest=$(docker buildx imagetools inspect "$family_base_image")
+          printf '%s\n' "$family_manifest"
+          for platform in $INPUT_PLATFORM; do
+            os="${platform%%_*}"
+            arch="${platform##*_}"
+            family_arch_image="$family_base_image-$arch"
+            printf '%s\n' "$family_manifest" | grep -E "^[[:space:]]*Platform:[[:space:]]+$os/$arch$"
+            docker pull --platform "$os/$arch" "$family_base_image"
+            docker tag "$family_base_image" "$family_arch_image"
+            docker image inspect "$family_arch_image"
+          done
           echo "family_base_image=$family_base_image" >> "$GITHUB_OUTPUT"
 
       - name: Publish Service Artifacts
@@ -366,6 +352,7 @@ jobs:
           PACKAGES_BATCH: ${{ steps.packages.outputs.packages_batch }}
           INPUT_VERSION: ${{ needs.publish-family.outputs.version }}
           INPUT_PLATFORM: ${{ inputs.platform }}
+          INPUT_CONCURRENCY: ${{ inputs.concurrency }}
           REGISTRY_ORG: ${{ env.CROSSPLANE_REGORG }}
           FAMILY_BASE_IMAGE: ${{ steps.family.outputs.family_base_image }}
           # We're using docker buildx, which doesn't actually load the images it
@@ -377,7 +364,7 @@ jobs:
           batch_platforms=$(tr ' ' ',' <<<"$INPUT_PLATFORM")
           df -h
           make \
-            CONCURRENCY=5 \
+            CONCURRENCY="$INPUT_CONCURRENCY" \
             SUBPACKAGES_FOR_BATCH="$PACKAGES_BATCH" \
             FAMILY_BASE_IMAGE="$FAMILY_BASE_IMAGE" \
             XPKG_REG_ORGS="$REGISTRY_ORG" \

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -187,7 +187,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ inputs.go-version }}
           cache: true
@@ -292,7 +292,7 @@ jobs:
         run: git fetch --prune --unshallow
 
       - name: Setup Go
-        uses: actions/setup-go@6edd4406fa81c3da01a34fa6f6343087c207a568 # v3
+        uses: actions/setup-go@924ae3a1cded613372ab5595356fb5720e22ba16 # v6
         with:
           go-version: ${{ inputs.go-version }}
           cache: true

--- a/.github/workflows/publish-provider-packages.yaml
+++ b/.github/workflows/publish-provider-packages.yaml
@@ -242,7 +242,6 @@ jobs:
   publish-services:
     if: ${{ needs.index.outputs.has_services == 'true' }}
     strategy:
-      max-parallel: 4
       matrix:
         index: ${{ fromJSON(needs.index.outputs.indices) }}
 

--- a/Makefile
+++ b/Makefile
@@ -407,6 +407,9 @@ Batch Processing:
                           Example: make build-subpackages SUBPACKAGES_FOR_BATCH="config,networking" BATCH_PLATFORMS=linux_amd64
     publish-subpackages   Build and push sub-packages to registry
                           Example: make publish-subpackages SUBPACKAGES_FOR_BATCH="config,networking" BATCH_PLATFORMS=linux_amd64
+    publish-service-subpackages
+                          Build and push service sub-packages using an already published family provider image
+                          Example: make publish-service-subpackages SUBPACKAGES_FOR_BATCH="networking" FAMILY_BASE_IMAGE=ghcr.io/org/provider-family-oci:v1.0.0 BATCH_PLATFORMS=linux_amd64
 
 endef
 # The reason CROSSPLANE_MAKE_HELP is used instead of CROSSPLANE_HELP is because the crossplane

--- a/build/makelib/subpackage.mk
+++ b/build/makelib/subpackage.mk
@@ -14,6 +14,7 @@ endif
 BUILD_ONLY ?= false
 STORE_PACKAGES ?= ""
 XPKG_CLEANUP_EXAMPLES_VERSION ?= v0.12.1
+FAMILY_BASE_IMAGE ?= $(BUILD_REGISTRY)/$(PROJECT_NAME)
 
 # Default sub-packages for batch processing
 # Override with: make publish-subpackages SUBPACKAGES_FOR_BATCH="config,networking,containerengine"
@@ -90,7 +91,7 @@ batch-process: $(UP) kustomize-crds
 	done; \
 	mkdir -p "$(XPKG_OUTPUT_DIR)/$(PLATFORM)" && \
 	$(UP) xpkg batch --smaller-providers "$(SUBPACKAGES_FOR_BATCH)" \
-		--family-base-image $(BUILD_REGISTRY)/$(PROJECT_NAME) \
+		--family-base-image $(FAMILY_BASE_IMAGE) \
 		--platform $(BATCH_PLATFORMS) \
 		--provider-name $(PROJECT_NAME) \
 		--family-package-url-format $(XPKG_REG_ORGS)/%s:$(VERSION) \
@@ -145,4 +146,21 @@ publish-subpackages: kustomize-crds
 	done; \
 	$(MAKE) batch-process SUBPACKAGES_FOR_BATCH="$(SUBPACKAGES_FOR_BATCH)" BUILD_ONLY=false BATCH_PLATFORMS="$(BATCH_PLATFORMS)"
 
-.PHONY: batch-process build-subpackages publish-subpackages build.family.image
+# Build and push service sub-packages using an already published family provider image.
+# Usage: make publish-service-subpackages SUBPACKAGES_FOR_BATCH="networking,containerengine" FAMILY_BASE_IMAGE=ghcr.io/org/provider-family-oci:v1.0.0
+publish-service-subpackages:
+	@case ",$(SUBPACKAGES_FOR_BATCH)," in \
+		*,config,*) \
+			echo "Error: publish-service-subpackages does not accept config in SUBPACKAGES_FOR_BATCH."; \
+			exit 1; \
+			;; \
+	esac
+	@if [ "$(FAMILY_BASE_IMAGE)" = "$(BUILD_REGISTRY)/$(PROJECT_NAME)" ]; then \
+		echo "Error: FAMILY_BASE_IMAGE must reference the pulled provider-family-oci image."; \
+		exit 1; \
+	fi
+	@PLATFORMS_FOR_BUILD=$$(echo "$(BATCH_PLATFORMS)" | tr ',' ' '); \
+	$(MAKE) build PLATFORMS="$$PLATFORMS_FOR_BUILD" SUBPACKAGES="$(SUBPACKAGES_FOR_BATCH)"; \
+	$(MAKE) batch-process SUBPACKAGES_FOR_BATCH="$(SUBPACKAGES_FOR_BATCH)" BUILD_ONLY=false BATCH_PLATFORMS="$(BATCH_PLATFORMS)" FAMILY_BASE_IMAGE="$(FAMILY_BASE_IMAGE)"
+
+.PHONY: batch-process build-subpackages publish-subpackages publish-service-subpackages build.family.image

--- a/build/makelib/subpackage.mk
+++ b/build/makelib/subpackage.mk
@@ -15,6 +15,7 @@ BUILD_ONLY ?= false
 STORE_PACKAGES ?= ""
 XPKG_CLEANUP_EXAMPLES_VERSION ?= v0.12.1
 FAMILY_BASE_IMAGE ?= $(BUILD_REGISTRY)/$(PROJECT_NAME)
+SKIP_GO_CACHE_CLEAN ?= false
 
 # Default sub-packages for batch processing
 # Override with: make publish-subpackages SUBPACKAGES_FOR_BATCH="config,networking,containerengine"
@@ -137,7 +138,7 @@ build-subpackages:
 publish-subpackages: kustomize-crds
 	@PLATFORMS_FOR_BUILD=$$(echo "$(BATCH_PLATFORMS)" | tr ',' ' '); \
 	$(MAKE) build PLATFORMS="$$PLATFORMS_FOR_BUILD" SUBPACKAGES="$(SUBPACKAGES_FOR_BATCH)"; \
-	$(GO) clean -cache -testcache || true; \
+	if [ "$(SKIP_GO_CACHE_CLEAN)" != "true" ]; then $(GO) clean -cache -testcache || true; fi; \
 	docker buildx prune -af || true; \
 	for platform in $$PLATFORMS_FOR_BUILD; do \
 		docker buildx prune -af || true; \


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

Optimize publish by building and publishing the family provider once, then reusing it across service publish jobs.

**Previous Strategy**

```text
index: calculate batches
publish-artifacts[0]: make generate -> build family -> build service(s) -> publish split[0]
publish-artifacts[1]: make generate -> build family -> build service(s) -> publish split[1]
publish-artifacts[N]: make generate -> build family -> build service(s) -> publish split[N]
```

**New Strategy**

```text
index: calculate batches
publish-family: re-use cache (old workflow) -> make check-diff -> build family -> publish family
publish-services[0]: re-use cache -> re-use family -> build service(s) -> publish service(s) split[0]
publish-services[1]: re-use cache -> re-use family -> build service(s) -> publish service(s) split[1]
publish-services[N]: re-use cache -> re-use family -> build service(s) -> publish service(s) split[N]
```

**Changes**

- Split family publish from service fan-out.
- Removed repeated family provider builds from service jobs.
- Added service-only publish path using `FAMILY_BASE_IMAGE`.
- Reused Go cache and published `provider-family-oci:<version>` in service jobs.

<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

I have:

- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

Successful runs:

Cache-miss: https://github.com/veera-adithya-d/crossplane-provider-oci/actions/runs/28137674924
Cache-hit: https://github.com/veera-adithya-d/crossplane-provider-oci/actions/runs/28140626025

<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
