### PR TITLE
fix: omit unset OCI provider credentials

### DIFF
--- a/internal/clients/oci.go
+++ b/internal/clients/oci.go
@@ -87,7 +87,7 @@ func TerraformSetupBuilder(version, providerSource, providerVersion string) terr
 }
 
 func terraformProviderConfig(ociCreds map[string]string) terraform.ProviderConfiguration {
-	return terraform.ProviderConfiguration{
+	config := terraform.ProviderConfiguration{
 		credentialKeyTenancyOCID:                     ociCreds[credentialKeyTenancyOCID],
 		credentialKeyUserOCID:                        ociCreds[credentialKeyUserOCID],
 		credentialKeyPrivateKey:                      ociCreds[credentialKeyPrivateKey],
@@ -107,6 +107,14 @@ func terraformProviderConfig(ociCreds map[string]string) terraform.ProviderConfi
 		credentialKeyTokenExchangeRPSTExpiration:     ociCreds[credentialKeyTokenExchangeRPSTExpiration],
 		credentialKeyTokenExchangePublicKey:          ociCreds[credentialKeyTokenExchangePublicKey],
 	}
+
+	for key, value := range config {
+		if value == "" {
+			delete(config, key)
+		}
+	}
+
+	return config
 }
 
 func resolveProviderConfig(ctx context.Context, kube client.Client, mg resource.Managed) (*namespacedv1beta1.ProviderConfigSpec, error) {

--- a/internal/clients/oci_test.go
+++ b/internal/clients/oci_test.go
@@ -32,3 +32,47 @@ func TestTerraformProviderConfigIncludesWorkloadIdentityFederation(t *testing.T)
 		}
 	}
 }
+
+func TestTerraformProviderConfigOmitsUnsetInstancePrincipalCredentials(t *testing.T) {
+	creds := map[string]string{
+		credentialKeyTenancyOCID: "ocid1.tenancy.oc1..example",
+		credentialKeyAuth:        "InstancePrincipal",
+		credentialKeyRegion:      "us-ashburn-1",
+	}
+
+	cfg := terraformProviderConfig(creds)
+
+	if len(cfg) != len(creds) {
+		t.Fatalf("len(cfg) = %d, want %d", len(cfg), len(creds))
+	}
+	for key, want := range creds {
+		if got, ok := cfg[key]; !ok || got != want {
+			t.Fatalf("cfg[%q] = %v, %t, want %q, true", key, got, ok, want)
+		}
+	}
+	if _, ok := cfg[credentialKeyTokenExchangeAuth]; ok {
+		t.Fatalf("cfg unexpectedly includes %q", credentialKeyTokenExchangeAuth)
+	}
+}
+
+func TestTerraformProviderConfigOmitsUnsetOKEWorkloadIdentityCredentials(t *testing.T) {
+	creds := map[string]string{
+		credentialKeyTenancyOCID: "ocid1.tenancy.oc1..example",
+		credentialKeyAuth:        "OKEWorkloadIdentity",
+		credentialKeyRegion:      "us-ashburn-1",
+	}
+
+	cfg := terraformProviderConfig(creds)
+
+	if len(cfg) != len(creds) {
+		t.Fatalf("len(cfg) = %d, want %d", len(cfg), len(creds))
+	}
+	for key, want := range creds {
+		if got, ok := cfg[key]; !ok || got != want {
+			t.Fatalf("cfg[%q] = %v, %t, want %q, true", key, got, ok, want)
+		}
+	}
+	if _, ok := cfg[credentialKeyTokenExchangeAuth]; ok {
+		t.Fatalf("cfg unexpectedly includes %q", credentialKeyTokenExchangeAuth)
+	}
+}


### PR DESCRIPTION
<!--
Please read through https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md if this is your first time opening a
pull request to this repo. Find us in https://crossplane.slack.com
if you need any help contributing.
-->

### Description of your changes

Fix OCI provider configuration generation to omit optional authentication fields that are not set in the Crossplane credential secret.

Previously, `terraformProviderConfig` included all supported credential fields, using empty strings for missing values. With `InstancePrincipal` authentication, this added:

`"token_exchange_auth": ""`

`token_exchange_auth` is only used for Workload Identity Federation. The Terraform Provider OCI validates this field whenever it is present and rejects an empty value, causing valid `InstancePrincipal` reconciliations to fail.

This change removes empty values from the provider configuration before passing it to Terraform. Terraform now receives only the credentials that were explicitly supplied, such as `tenancy_ocid`, `auth: InstancePrincipal`, and `region`.
<!--
Briefly describe what this pull request does. Be sure to direct your
reviewers' attention to anything that needs special consideration.

We love pull requests that resolve an open issue. If yours does, you
can uncomment the below line to indicate which issue your PR fixes, for example
"Fixes #500":
-->

Fixes #

Remove empty values from the Terraform provider configuration map before it is consumed by Terraform. This preserves only the credential fields actually supplied. For `InstancePrincipal`, Terraform now receives values such as `tenancy_ocid`, `auth: InstancePrincipal`, and `region`, without unrelated WIF fields.

I have:


- [x] Read and followed Crossplane's [contribution process].
- [x] Run `make generate` and committed the results (ideally in a separate commit). <!-- It's normal for this to appear to stall for several minutes with no visible output -->
- [x] Not made any manual changes to generated files, and verified this with `make check-diff`.

### How has this code been tested

Added a regression test confirming that unset `InstancePrincipal` credential fields, including `token_exchange_auth`, are omitted from the Terraform configuration.

Also validated the change by:

- Building and publishing the service providers.
- Installing them on an OKE cluster.
- Creating a ClusterProviderConfig using an InstancePrincipal secret.
- Successfully creating resources without token-exchange validation errors.
<img width="774" height="511" alt="Screenshot 2026-07-18 at 2 29 27 PM" src="https://github.com/user-attachments/assets/e3c7eeb0-c86e-43f7-8cd8-3c0fa3a0cb14" />
<img width="1486" height="762" alt="Screenshot 2026-07-18 at 3 32 31 PM" src="https://github.com/user-attachments/assets/2870fba8-5c19-4cee-b4b6-9904054f9811" />


<!--
Before reviewers can be confident in the correctness of this pull request, it
needs to tested and shown to be correct. Briefly describe the testing that has
already been done or which is planned for this change.
-->

[contribution process]: https://github.com/oracle/crossplane-provider-oci/blob/main/CONTRIBUTING.md
