### PR TITLE
fix: clean generated files before package loading

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -215,7 +215,22 @@ pull-docs:
 	fi
 	@git -C "$(WORK_DIR)/$(TERRAFORM_PROVIDER_SOURCE)" sparse-checkout set "$(TERRAFORM_DOCS_PATH)"
 
-generate.init: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs
+# Go resolves every package and snapshots its source file list before executing
+# any go:generate directive. Clean generated files in a separate make process so
+# resource moves do not leave go generate trying to read a deleted source path.
+generate.clean:
+	@$(INFO) cleaning generated files
+	@rm -rf package/crds
+	@find apis -iname 'zz_*' -delete
+	@find apis -type d -empty -delete
+	@find internal/controller -iname 'zz_*' -delete
+	@find internal/controller -type d -empty -delete
+	@find cmd/provider -name 'zz_*' -type f -delete
+	@find cmd/provider -type d -maxdepth 1 -mindepth 1 -empty -delete
+	@rm -rf examples-generated
+	@$(OK) cleaning generated files
+
+generate.init: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs generate.clean
 
 # Transform resolver references to use scheme-based resolution for sub-package architecture
 generate.resolve: generate
@@ -229,7 +244,7 @@ build.complete: generate.resolve build
 	@$(INFO) complete build workflow finished
 	@$(OK) complete build workflow finished
 
-.PHONY: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs generate.resolve build.complete
+.PHONY: $(TERRAFORM_PROVIDER_SCHEMA) pull-docs generate.clean generate.resolve build.complete
 # ====================================================================================
 # Targets
 

--- a/apis/generate.go
+++ b/apis/generate.go
@@ -8,18 +8,6 @@ Copyright 2021 Upbound Inc.
 // NOTE: See the below link for details on what is happening here.
 // https://github.com/golang/go/wiki/Modules#how-can-i-track-tool-dependencies-for-a-module
 
-// Remove existing CRDs
-//go:generate rm -rf ../package/crds
-
-// Remove generated files
-//go:generate bash -c "find . -iname 'zz_*' -delete"
-//go:generate bash -c "find . -type d -empty -delete"
-//go:generate bash -c "find ../internal/controller -iname 'zz_*' -delete"
-//go:generate bash -c "find ../internal/controller -type d -empty -delete"
-//go:generate bash -c "find ../cmd/provider -name 'zz_*' -type f -delete"
-//go:generate bash -c "find ../cmd/provider -type d -maxdepth 1 -mindepth 1 -empty -delete"
-//go:generate rm -rf ../examples-generated
-
 // Generate documentation from Terraform docs.
 //go:generate go run github.com/crossplane/upjet/v2/cmd/scraper -n ${TERRAFORM_PROVIDER_SOURCE} -r ../.work/${TERRAFORM_PROVIDER_SOURCE}/${TERRAFORM_DOCS_PATH} -o ../config/provider-metadata.yaml
 


### PR DESCRIPTION
## Summary

- move generated-file cleanup out of `apis/generate.go`
- add a dedicated `generate.clean` Make target
- run cleanup during `generate.init`, before `go generate` loads packages

## Why

`go generate` discovers packages and snapshots their source-file paths before executing any `//go:generate` directives. If a handwritten group mapping moves a resource after an initial Terraform-provider regeneration, the in-process cleanup deletes the old generated path and Upjet recreates the resource only under the corrected group. The still-running outer `go generate` then tries to scan the deleted path and fails with `no such file or directory`.

Cleaning in a separate Make phase ensures that `go generate` builds its package list from an already-clean tree.

## Validation

- `git diff --check`
- dry-run confirmed `generate.clean` completes before `generate.run`
- Terraform provider 8.22.0 to 8.23.0 workflow completed initial generation, handwritten group remediation, regeneration, and build with this patch
